### PR TITLE
Swap wget for curl

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Run the *install.sh* script:
 
 ```bash
 # download the installer
-wget https://raw.githubusercontent.com/neurobin/pacget/release/install.sh -O install.sh
+curl -O https://raw.githubusercontent.com/neurobin/pacget/release/install.sh
 chmod +x install.sh # Give execute permission
 ./install.sh        # Run the installer
 ```


### PR DESCRIPTION
Base installation hasn't had wget in a long time. No sense in installing wget just for this one install script.